### PR TITLE
AVADDON is down

### DIFF
--- a/ransomware_gang.md
+++ b/ransomware_gang.md
@@ -1,6 +1,6 @@
 |Name|Link|Status|User:Password|Tox ID|
 | ------ | ------ | ------ | ------ | ------ |
-|AVADDON| http://avaddongun7rngel.onion/|||
+|AVADDON| http://avaddongun7rngel.onion/|(CURRENTLY DOWN)||
 |SODINOKIBI (REVIL)| http://dnpscnbaix6nkwvystl3yxglz7nteicqrou3t75tpcc5532cztc46qyd.onion/|||
 |NEFILIM| http://hxt254aygrsziejn.onion/|||
 |VFOKX (1)| http://vfokxcdzjbpehgit223vzdzwte47l3zcqtafj34qrr26htjo4uf3obid.onion/|||


### PR DESCRIPTION
Avaddon retired around 12 June 2021, and the onion web page is down since then.