### PR TITLE
New RaidForum mirror

### DIFF
--- a/forum.md
+++ b/forum.md
@@ -43,6 +43,7 @@
 |RAID FORUM| https://raidforums.com/|
 |RAID FORUM (mirror 1)| https://rf.ws|
 |RAID FORUM (mirror 2)| https://raid.lol/|
+|RAID FORUM (mirror 3)| https://rfmirror.com/|
 |RAMP| http://ramp4u5iz4xx75vmt6nk5xfrs5mrmtokzszqxhhkjqlk7pbwykaz7zid.onion/login/|
 |RUTOR| https://darknet.rutor.nl/|
 |SINISTER| https://sinister.ly/|


### PR DESCRIPTION
More info: https://www.bleepingcomputer.com/news/security/raidforums-forced-to-use-mirror-after-brazilian-govt-contacts-registrar/