### PR TITLE
Added CVE-2022-42475

### DIFF
--- a/cve_most_exploited.md
+++ b/cve_most_exploited.md
@@ -13,6 +13,7 @@
 |Drupal |CVE-2018-7600 |Remote code execution (RCE) |https://github.com/a2u/CVE-2018-7600|
 |Fortinet |CVE-2018-13379 |Path traversal |https://github.com/milo2012/CVE-2018-13382|
 |Fortinet |CVE-2022-40684 |Authentication Bypass |https://github.com/horizon3ai/CVE-2022-40684|
+|Fortinet |CVE-2022-42475 |Remote code execution (RCE)||
 |F5 Big IP |CVE 2020-5902 |Remote code execution (RCE)|https://pentest-tools.com/blog/big-ip-tmui-rce/|
 |Log4j |CVE-2021-44228 |Remote code execution (RCE)|https://github.com/kozmer/log4j-shell-poc|
 |F5 Big IP |CVE-2022-1388 |Remote Code execution (RCE)|https://github.com/alt3kx/CVE-2022-1388_PoC|


### PR DESCRIPTION
Added CVE-2022-42475 - https://thehackernews.com/2023/01/fortios-flaw-exploited-as-zero-day-in.html