### PR TITLE
Update telegram_threat_actors.md

### DIFF
--- a/telegram_threat_actors.md
+++ b/telegram_threat_actors.md
@@ -323,6 +323,8 @@
 |https://t.me/LulzSecOff|OFFLINE|LulzSec||
 |https://t.me/LummaC2Stealer|OFFLINE|LummaC2 Stealer|Infostealer|
 |https://t.me/LummaC2Team|OFFLINE|LummaC2 Stealer Chat|Infostealer|
+|https://t.me/LummaReborn|ONLINE|LummaC2 Stealer Channel|Infostealer|
+|https://t.me/LummaTeam_Reborn|ONLINE|LummaC2 Stealer Chat|Infostealer|
 |https://t.me/+lYYyb3exPNFjNmRi|VALID|Cyber Dragon||
 |https://t.me/+LZQBX9ml0Qk3YWFl|EXPIRED|BF Repo V3 Chat||
 |https://t.me/MAilAccessCracker|ONLINE|Free Data Breaches Provider||


### PR DESCRIPTION
Lumma Stealer, a notorious tool in cybercriminal activities, were recently shut down. Following the bans, the group has made a swift return, establishing new channels and accounts to continue their operations.