### PR TITLE
Remove duplicate telegram entry for Okto Dark Cyber Squad - expired link

### DIFF
--- a/telegram_threat_actors.md
+++ b/telegram_threat_actors.md
@@ -15,7 +15,6 @@
 |https://t.me/+AAAAAEedZM6cBNj764phgQ|EXPIRED|Large Hacking Group||
 |https://t.me/+AAAAAFGhhcV9p1Rm2f_Emw|EXPIRED|||
 |https://t.me/+AAAAAFNLmVP0ZCy51tNOig|VALID|Forum||
-|https://t.me/+aC3mHL9kVhBhNzM1|VALID|Okto Dark Cyber Squad||
 |https://t.me/+B3LXsqUjJcs4ZGI0|EXPIRED|NoName057(16) France🇫🇷 - april 2025|DDoS|
 |https://t.me/+Bat9QqJcSuE0MTg1|VALID|AresLoader||
 |https://t.me/+BnYEQZsweIRlZThh|EXPIRED|R3An0nymous Chat|DDoS|


### PR DESCRIPTION
The telegram invite link for Okto Dark Cyber Squad is expired, and [already exists on line 713 ](https://github.com/fastfire/deepdarkCTI/blob/4a6e7660367f2d0a840302aea60d5fffd72bfe5d/telegram_threat_actors.md?plain=1#L713)as an expired link. This p/r cleans up the duplicate link that the status as valid.