### PR TITLE
Add current mirror for DARKNET ARMY forum

### DIFF
--- a/forum.md
+++ b/forum.md
@@ -123,6 +123,7 @@
 | [DARKMARKET.CX](https://darkmarket.cx)                                                                                                     | OFFLINE          |                                  |
 | [DARKMONEY](https://darkmoney.lc)                                                                                                          | ONLINE           |                                  |
 | [DARKNET ARMY](http://dna777ucpo4unwxrzw5mzs4iqm5qz3uepw3k5mvwbt7tnufryvsgy5yd.onion)                                                      | ONLINE           |                                  |
+| [DARKNET ARMY](http://darknet77vonbqeatfsnawm5jtnoci5z22mxay6cizmoucgmz52mwyad.onion)                                                      | ONLINE           |                                  |
 | [DARKNET](https://darknet.ug)                                                                                                              | ONLINE           |                                  |
 | [DARKNETWORLD](https://www.darknetworld.com)                                                                                               | OFFLINE          |                                  |
 | [DARKPID](https://darkpid.com)                                                                                                             | ONLINE           |                                  |


### PR DESCRIPTION
Adds the currently active onion mirror for the DARKNET ARMY forum already listed in `forum.md`. Confirmed it's the same forum (mirror of the existing entry) before submitting, and verified this address is alive.