### PR TITLE
Add SHADOW FORUM (Turkish .onion forum)

### DIFF
--- a/forum.md
+++ b/forum.md
@@ -292,6 +292,7 @@
 | [RUTOR (Surface)](http://rutor.live)                                                                                                       | OFFLINE          |                                  |
 | [SECRET FORUM PROPAGANDA](http://qvwje7edtrfby6pfnm3q7o3lju22mfx3xsjyl3y33l66sbq3qcnlmvad.onion)                                           | ONLINE           |                                  |
 | [SEOPIRAT](https://seopirat.club)                                                                                                          | ONLINE           |                                  |
+| [SHADOW FORUM](http://w4ljqtyjnxinknz4hszn4bsof7zhfy5z2h4srfss4vvkoikiwz36o3id.onion)                                                      | ONLINE           |                                  |
 | [SINFUL](https://sinfulsite.com)                                                                                                           | ONLINE           |                                  |
 | [SINISTER](https://sinister.ly)                                                                                                            | ONLINE           |                                  |
 | [SKYFRAUD](http://bcbm4y7yusdxthg3.onion)                                                                                                  | OFFLINE          |                                  |


### PR DESCRIPTION
Adds SHADOW FORUM, a Turkish-language MyBB forum on Tor, to `forum.md`.

- Sections include data leaks, carding, cracking and counterfeiting, so it fits the scope of the file.
- Verified alive (HTTP 200) at the time of this PR.
- Checked it is not already listed under a different address or name.
- Inserted in alphabetical order; description left empty to match the file convention.