### PR TITLE
Add DEEP ANSWERS forum

### DIFF
--- a/forum.md
+++ b/forum.md
@@ -138,6 +138,7 @@
 | [DATACLOUD](https://datacloud.space)                                                                                                       | ONLINE           |                                  |
 | [DATAFORUMS](https://dataforums.co)                                                                                                        | ONLINE           |                                  |
 | [DEDICATET](https://dedicatet.com)                                                                                                         | ONLINE           |                                  |
+| [DEEP ANSWERS](http://deeptyspkdq3nfvqvyzbkgwhtok4qoyhypsyiuo24wux4jnb6e3nyiqd.onion)                                                      | ONLINE           |                                  |
 | [DEFCON](http://ezdhgsy2aw7zg54z6dqsutrduhl22moami5zv2zt6urr6vub7gs6wfad.onion)                                                            | OFFLINE          |                                  |
 | [DEMONFORUMS](https://demonforums.net)                                                                                                     | ONLINE           |                                  |
 | [DOXBYTE](https://doxbyte.com)                                                                                                             | ONLINE           |                                  |


### PR DESCRIPTION
`Deep Answers` is a Portuguese-language Q&A forum on Tor (`deeptysp…onion`), with Spanish and English interfaces as well. The home page reports ~9.5k questions, ~26k answers and ~5.9k users.

Not present in the repository by address or by name. The address is listed by several public onion directories (e.g. opensourcebrasil.blogspot.com "Deep Web" page).

Checked 2026-09-13: HTTP 200, page title `Deep Answers`.