### PR TITLE
Add DIGITAL THRIFT SHOP market

### DIFF
--- a/markets.md
+++ b/markets.md
@@ -66,6 +66,7 @@
 |[Dark Matter](http://darkmat3kdxestusl437urshpsravq7oqb7t3m36u2l62vnmmldzdmid.onion)| ONLINE | |
 |[Dark Matter](http://darkmmk3owyft4zzg3j3t25ri4z5bw7klapq6q3l762kxra72sli4mid.onion)| ONLINE | |
 |[Dark Matter](http://darkmmro6j5xekpe7jje74maidkkkkw265nngjqxrv4ik7v3aiwdbtad.onion)| ONLINE | |
+|[DIGITAL THRIFT SHOP](http://kw4zlnfhxje7top26u57iosg55i7dzuljjcyswo2clgc3mdliviswwyd.onion)| ONLINE | |
 |[DOCSHOP](https://doc-shop.ws)| OFFLINE | |
 |[EMPIRE MARKET](http://2a2a2abbjsjcjwfuozip6idfxsxyowoi3ajqyehqzfqyxezhacur7oyd.onion)| ONLINE | |
 |[ETERNITY](http://malwarewrn7fvd7zq243d74dxs3ca4wh5kw6i2opkzeusuoajtd2j5yd.onion)| ONLINE | |


### PR DESCRIPTION
`Digital Thrift Shop` is a Tor vendor shop selling digital goods only — databases, data leaks, botnets, stealers, RATs, keyloggers and documents/guides. It has a full storefront (catalog, cart, checkout, accounts, FAQ) and its own subdread (`/d/dts`).

Not present in the repository by address or by name. The exact address is listed by onion.live (online, no scam/phishing flag) and by public onion trackers.

Checked 2026-09-13: HTTP 200, page title `Digital Thrift Shop – Best digital stuff in Tor network!`.