### PR TITLE
Add RUNION forum

### DIFF
--- a/forum.md
+++ b/forum.md
@@ -284,6 +284,7 @@
 | [REVERSING](https://reversing.center)                                                                                                      | ONLINE           |                                  |
 | [RF-CHEAT](https://www.rf-cheats.ru)                                                                                                       | ONLINE           |                                  |
 | [ROOTSPLOIT](https://rootsploit.org)                                                                                                       | ONLINE           |                                  |
+| [RUNION](http://runionv3do7jdylpx7ufc6qkmygehsiuichjcstpj4hb2ycqrnmp67ad.onion)                                                            | ONLINE           |                                  |
 | [RUTOR (Dark)](http://rutordeepkpafpudl22pbbhzm4llbgncunvgcc66kax55sc4mp4kxcid.onion)                                                      | OFFLINE          |                                  |
 | [RUTOR (Dark)](http://rutorbesth5lhmj47qz4fi5i4x5zvh4fizruog6iw2l3q223jmnawvid.onion)                                                      | ONLINE           |                                  |
 | [RUTOR (Dark)](http://rutorclubwiypaf63caqzlqwtcxqu5w6req6h7bjnvdlm4m7tddiwoyd.onion)                                                      | ONLINE           |                                  |


### PR DESCRIPTION
`Runion` is a long-running Russian-language Tor forum (active since 2012; ~333k posts, ~20k threads). Sections include information security, OPSEC, hacking and intrusion, cryptocurrencies and a goods/services board, with the hacking sections active as of September 2026.

Not present in the repository by address or by name. This v3 address is declared by the forum itself in its pinned anti-phishing notice ("НАШ АДРЕС", by staff, 2023-11-21), which also lists the phishing clones — none of which are in the repository.

Checked 2026-09-13: HTTP 200, page title `Runion — Главная`.